### PR TITLE
Fix db start with more complex configuration

### DIFF
--- a/src/lcmap/clownfish/db.clj
+++ b/src/lcmap/clownfish/db.clj
@@ -62,7 +62,7 @@
   []
   (let [db-cfg (get-in config [:database :cluster])]
     (log/debugf "starting db with: %s" db-cfg)
-    (apply alia/cluster db-cfg)))
+    (alia/cluster db-cfg)))
 
 (defn db-cluster-stop
   "Shutdown cluster connection."


### PR DESCRIPTION
Don't apply alia/cluster, just call it. The former doesn't work with configuration maps with more than one key/value.