### PR TITLE
Provide results in tiles to reduce requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ HTTP endpoint for LCMAP change detection.
     "result_produced": "2017-01-01-17:57:33Z",
     "tile_update_requested": "2017-01-01-17:57:31Z",
     "inputs_url": "http://localhost:5678/landsat/tiles?x=123&y=456&acquired=2015-01-01/2017-01-01&ubid=LANDSAT_5/TM/sr_band1&ubid=LANDSAT_5/TM/sr_band2&ubid=LANDSAT_5/TM/sr_band3&ubid=LANDSAT_5/TM/sr_band4&ubid=LANDSAT_5/TM/sr_band5&ubid=LANDSAT_5/TM/sr_band7",
-    "inputs_md5": "189e725f4587b679740f0f7783745056"   
+    "inputs_md5": "189e725f4587b679740f0f7783745056"
    }
   ```
 
@@ -44,7 +44,7 @@ HTTP endpoint for LCMAP change detection.
     "x": 123,
     "y": 456,
     "tile_update_requested": "2017-01-01-17:57:31Z",
-    "inputs_url": "http://localhost:5678/landsat/tiles?x=123&y=456&acquired=2015-01-01/2017-01-01&ubid=LANDSAT_5/TM/sr_band1&ubid=LANDSAT_5/TM/sr_band2&ubid=LANDSAT_5/TM/sr_band3&ubid=LANDSAT_5/TM/sr_band4&ubid=LANDSAT_5/TM/sr_band5&ubid=LANDSAT_5/TM/sr_band7",
+     "inputs_url": "http://localhost:5678/landsat/tiles?x=123&y=456&acquired=2015-01-01/2017-01-01&ubid=LANDSAT_5/TM/sr_band1&ubid=LANDSAT_5/TM/sr_band2&ubid=LANDSAT_5/TM/sr_band3&ubid=LANDSAT_5/TM/sr_band4&ubid=LANDSAT_5/TM/sr_band5&ubid=LANDSAT_5/TM/sr_band7",
    }
   ```
   Successive calls return HTTP 202 until a result is available.
@@ -70,6 +70,49 @@ HTTP endpoint for LCMAP change detection.
       "y": 456
   }
   ```
+
+#### Get Multiple Change Results
+
+Retrieve all available change results near a point by sending an HTTP GET request.
+
+This approach reduces the number of requests required to retrieve data for an area,
+but it does not support arbitrary extents.
+
+```bash
+
+user@machine:~$ http GET http://localhost:5778/results/pyccd-beta1/tile?x=123&y=456
+
+{
+    "algorithm": "pyccd-beta1",
+    "algorithm-available": false,
+    "refresh": false,
+    "source-data-available": true,
+    "x": 123,
+    "y": 456
+}
+```
+
+The return status is HTTP 200 with a JSON response body. One of the entries will
+correspond to the point you requested.
+
+```
+  [{  "algorithm": "pyccd-beta1",
+      "algorithm-available": false,
+      "refresh": false,
+      "source-data-available": true,
+      "x": 123,
+      "y": 456
+   },
+   { "algorithm": "pyccd-beta1",
+      "algorithm-available": false,
+      "refresh": false,
+      "source-data-available": true,
+      "x": 124,
+      "y": 456
+   },
+   ...
+   ]
+```
 
 #### List available algorithms
   ```bash
@@ -148,7 +191,7 @@ Not yet on clojars.  A Docker image is available: ```docker pull usgseros/lcmap-
 user@machine:~/projects/lcmap/lcmap-changes$ make docker-deps-up-nodaemon
 # In another tab
 user@machine:~/projects/lcmap/lcmap-changes$ lein repl
-user=> (require '[lcmap.clownfish.setup.initialize :as initialize])  
+user=> (require '[lcmap.clownfish.setup.initialize :as initialize])
 user=> (initialize/cassandra environment)
 user=> (start)
 ```

--- a/src/lcmap/clownfish/endpoints.clj
+++ b/src/lcmap/clownfish/endpoints.clj
@@ -96,6 +96,11 @@
      (GET "/results/:algorithm{.+}/:x{[0-9-]+}/:y{[0-9-]+}" [algorithm x y]
        (with-meta
          (results/get-results algorithm x y request)
-         {:template html/default})))
+         {:template html/default}))
+
+     (GET "/results/:algorithm/tile" [algorithm]
+          (with-meta
+            (results/get-results-tile algorithm request)
+            {:template html/default})))
 
    prepare-with respond-with))

--- a/test/lcmap/clownfish/specifications_test.clj
+++ b/test/lcmap/clownfish/specifications_test.clj
@@ -264,6 +264,28 @@
         (is (= (set (keys expected))
                (set (keys result))))))
 
+    (testing "retrieve algorithm results for tile"
+      (let [algorithm test-algorithm
+            uri       (str http-host "/results/" algorithm "/tile")
+            params    {:x 123 :y 456}
+            resp      (req :get uri :query-params params)
+            results   (json/decode (resp :body) true)
+            expected  {:tile_x -585
+                       :tile_y 2805
+                       :algorithm test-algorithm
+                       :x 123
+                       :y 456
+                       :refresh false
+                       :tile_update_requested "{{now}} can't be determined"
+                       :inputs_url "{{now}} can't be determined"
+                       :inputs_md5 (digest/md5 "dummy inputs")
+                       :result test-algorithm-result
+                       :result_md5 (digest/md5 (str test-algorithm-result))
+                       :result_produced "{{now}} can't be determined"
+                       :result_ok true}]
+        (is (= 200 (:status resp)))
+        (is (every? (fn [actual] results-ok? expected actual) results))))
+
     (testing "reschedule algorithm when results already exist"
       (let [resp1  (get-results http-host {:algorithm test-algorithm
                                            :x 123 :y 456 :refresh false})


### PR DESCRIPTION
- Use tile-like approach; return a list of results for an area that contain the requested point.
- Define basic specification for new resource.

Other Notes:

The URL is /results/:algorithm-name/tile?x=:number&y=:number is similar to the way lcmap-landsat
provides data. I like that the algorithm name is part of the URL because it basically means,
"this algorithm is a network resource." By adding a "tile" subordinate resource we can provide
different chunks of data. Later, we can add another resource for retrieving arbitrary areas...